### PR TITLE
Fix clippy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [Overview](#overview)
 - [Traits](#traits)
+- [Running the code and the tests](#running-the-code-and-the-tests)
 - [To Do](#to-do)
 
 ## Overview
@@ -94,6 +95,52 @@ Adding this trait allows us to perform actions that require copying such as:
 ```rust
     result.push(v[i])
 ```
+
+Luckily integers (which is all we use here) already implement both the
+`PartialOrd` and the `Copy` traits, so we're good to go. If we needed to
+sort something more complex (like an array of student records), then we'd
+have to decide
+
+- How to implement the `PartialOrd` trait, perhaps by sorting by ID
+  numbers, or we could be brave and attempt some sort of sorting by
+  name.
+- If and how we are willing to implement the `Copy` trait. As a rule
+  we probably don't want to copy entire student records, so we'd have
+  to figure out what makes sense in our particular situation.
+
+## Running the code and the tests
+
+This is set up so that running the program (with `cargo run`) will run and
+time all three sorting algorithms on a randomly generated array of integers.
+Since insertion sort is O(N^2) and the other two are O(N log N), we would
+expect them to be faster. We might also expect quicksort to be faster (by
+a constant factor) than merge sort since quicksort doesn't need to copy
+elements around. Feel free to increase the value of the `size` constant
+at the top of the code to see how that affects the timing.
+
+Use `cargo test` to run the tests "by hand". The insertion sort tests
+should pass without you having to do anything. Some of the quicksort
+and merge sort tests may pass initially "for free" even though you know
+you haven't actually implemented anything. This is just because the
+default "silly" things that we do for those happen to be correct for
+things like empty lists of values.
+
+When running either the program or the tests, you'll initially get a
+warning like:
+
+```text
+warning: unused variable: `ys`
+   --> src/main.rs:171:75
+    |
+171 | fn merge<T: PartialOrd + std::marker::Copy + std::fmt::Debug>(xs: Vec<T>, ys: Vec<T>) -> Vec<T> {
+    |                                                                           ^^ help: if this is intentional, prefix it with an underscore: `_ys`
+    |
+    = note: `#[warn(unused_variables)]` on by default
+```
+
+This is just telling you that the stub code that we provided doesn't use the
+parameter `ys`. As you properly implement `merge()` you'll presumably use
+both arguments and this warning will go away.
 
 ## To Do
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,11 @@ use rand::{thread_rng, Rng};
 use std::time::{Instant};
 
 fn main() {
-    let size = 750000; // 100000;
+    // Feel free to raise size if you want to see the timing difference
+    // between the different algorithms. Since insertion sort is O(N^2)
+    // and the other two are O(N log N), you should definitely be able
+    // to see a difference between it and the two faster algorithms.
+    let size = 1000; // 100000;
     let v = generate_random_array(size, 0, size);
 
     let mut u = v.clone();
@@ -60,7 +64,7 @@ fn insertion_sort<T: PartialOrd + std::fmt::Debug>(v: &mut [T]) {
             // Since j-1 and j are out of order swap them, and move
             // j one to the left to continue the bubbling if necessary.
             v.swap(j-1, j);
-            j = j - 1;
+            j -= 1;
         }
     }
     // And we're done! The outer for loop is done O(N) times, and
@@ -104,7 +108,7 @@ fn quicksort<T: PartialOrd + std::fmt::Debug>(v: &mut [T]) {
     
     // ...
 
-    let smaller = 99999999; // Totally wrong – you should fix this.
+    let smaller = 0; // Totally wrong – you should fix this.
 
     // Sort all the items < pivot
     quicksort(&mut v[0..smaller]);
@@ -152,8 +156,12 @@ fn merge_sort<T: PartialOrd + std::marker::Copy + std::fmt::Debug>(v: &[T]) -> V
     let middle = v.len() / 2; //rounds down by default
     let left = merge_sort(&v[0..middle]);
     let right = merge_sort(&v[middle .. len]);
-    let result = merge(left, right);
-    return result
+    // Note that in Rust the last expression is what is
+    // returned, and we don't need the explicit `return`
+    // keyword. So this merges `left` and `right` and
+    // returns the result as the result of this call to
+    // `merge_sort()`.
+    merge(left, right)
 }
 
 // "Out of the box" there's a warning here about `ys` being
@@ -176,7 +184,7 @@ fn merge<T: PartialOrd + std::marker::Copy + std::fmt::Debug>(xs: Vec<T>, ys: Ve
 
     // This is totally wrong and will not sort. You should replace it
     // with something useful. :)
-    return xs;
+    xs
 }
 
 fn is_sorted<T: PartialOrd>(slice: &[T]) -> bool {
@@ -186,7 +194,7 @@ fn is_sorted<T: PartialOrd>(slice: &[T]) -> bool {
             return false;
         }
     }
-    return true;
+    true
 }
 
 fn generate_random_array(len: i32, min: i32, max:i32) -> Vec<i32> {
@@ -195,7 +203,9 @@ fn generate_random_array(len: i32, min: i32, max:i32) -> Vec<i32> {
     for _i in 0..len{
         v.push(rng.gen_range(min, max));
     }
-    return v;
+    // Rust returns the last expression in a function, so
+    // this is equivalent to `return v`. 
+    v
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This fixes several warnings, most of which were because I kept using `return` like I was some kind of Java programmer. 😜 

There's one unused parameter warning I can't easily make go away, but which should go away when they implement the `merge()` function. I documented that both in the code and in the README.

Closes #3